### PR TITLE
Fix closing connections and files

### DIFF
--- a/app.py
+++ b/app.py
@@ -103,18 +103,15 @@ def render_settings(action):
         config_file_content = ""
         message = ""
         if action == 'edit':
-            f = open(config, "r")
-            config_file_content = f.read()
-            f.close
+            with open(config, "r") as f:
+                config_file_content = f.read()
         if action == 'save':
             # back it up first
-            src = open(config, "r")
-            dest = open(config + ".bak", "w")
-            dest.write(src.read())
+            with open(config, "r") as src, open(config + ".bak", "w") as dest:
+                dest.write(src.read())
 
-            f = open(config, "w")
-            f.write(request.form["settings"])
-            f.close
+            with open(config, "w") as f:
+                f.write(request.form["settings"])
             message = "success"
         return render_template("settings.html", config_file_content=config_file_content, message=message)
     except Exception as e:

--- a/mdb.py
+++ b/mdb.py
@@ -89,7 +89,7 @@ def get_all_dbs_and_tables(db, server):
                 # hide tables as per global or per server config
                 if table['tables'] not in table_exception_list:
                     all_dbs[server][i['name']].append(table['tables'])
-        db['cnf']['servers'][server]['cur'].close
+        db['cnf']['servers'][server]['cur'].close()
         return all_dbs
     except (mysql.connector.Error, mysql.connector.Warning) as e:
         raise ValueError(e)
@@ -113,7 +113,7 @@ def get_table_content(db, server, database, table):
 
         return content
     except (mysql.connector.Error, mysql.connector.Warning) as e:
-        db['cnf']['servers'][server]['conn'].close
+        db['cnf']['servers'][server]['conn'].close()
         raise ValueError(e)
 
 def execute_adhoc_report(db, server):


### PR DESCRIPTION
Use context manager so we close the file descriptor all they time. (It calls `close()` implicitly)
 Also, so close is a function, so we should include the `()`.